### PR TITLE
new height for first section homepage in min-width:1536px

### DIFF
--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -77,7 +77,7 @@ export default function Home() {
             <Head>
                 <title>Page d'accueil - Easy Gift</title>
             </Head>
-            <section className='my-10 min-h-40 h-auto flex flex-initial flex-wrap content-start items-center mx-auto w-4/5 md:my-28 md:min-h-80 md:justify-evenly md:max-w-2xl lg:flex-nowrap lg:my-44 lg:max-w-7xl xl:my-20 xl:min-h-120  2xl:max-w-[1800px] 2xl:min-h-150 2xl:content-center 2xl:my-40'>
+            <section className='my-10 min-h-40 h-auto flex flex-initial flex-wrap content-start items-center mx-auto w-4/5 md:my-28 md:min-h-80 md:justify-evenly md:max-w-2xl lg:flex-nowrap lg:my-44 lg:max-w-7xl xl:my-20 xl:min-h-120  2xl:max-w-[1800px] 2xl:h-[85vh] 2xl:content-center 2xl:my-0'>
                 <div className='hidden relative w-full order-2 md:block md:max-w-4xl md:min-w-96 lg:mb-24 lg:order-1 lg:max-w-xl:min-h-130 lg:max-w-lg 2xl:max-w-4xl'>
                     <Image
                         src='/images/img-pages/hero-img.png'


### PR DESCRIPTION
J'ai laissé tous les formats comme ils étaient SAUF le dernier qui démarre à partir de 1536px,
 pas d'autres breakpoint avec tailwind malheureusement.
 J'ai fait en sorte qu'à partir de ce breakpoint "2xl" la section soit à  une height de 85vh, 
 ce qui nous permet d'avoir toujours le même résultat peu importe la Height de notre écran. 

Bien vu les filles, il y avait vraiment trop d'espace avec pc plus petit 👍 

le reste reste inchangé car réfléchit pour les autres devices. 